### PR TITLE
Auto uppercase middle name

### DIFF
--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -515,6 +515,8 @@ MIDDLE_NAME_ABBREVS: FrozenSet[str] = frozenset(
 # Not name abbreviations if not followed by period
 NOT_NAME_ABBREVS: FrozenSet[str] = frozenset(("á", "í"))
 
+# Words which should probably be lowercase
+PREFER_LOWERCASE: FrozenSet[str] = frozenset(("á", "bóndi", "ganga", "hæð"))
 
 def load_token(*args: Any) -> Tuple[int, str, ValType]:
     """ Convert a plain, usually JSON serialized, argument tuple
@@ -694,6 +696,8 @@ def annotate(
                                 )
                                 for mm in m
                             ]
+            if auto_uppercase and t.txt in PREFER_LOWERCASE:
+                w = t.txt
             # Yield a word tuple with meanings
             yield token_ctor.Word(w if auto_uppercase else t.txt, m, token=t)
         else:

--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -695,10 +695,13 @@ def annotate(
                                 )
                                 for mm in m
                             ]
-            if auto_uppercase and t.txt in PREFER_LOWERCASE:
-                w = t.txt
+
             # Yield a word tuple with meanings
-            yield token_ctor.Word(w if auto_uppercase else t.txt, m, token=t)
+            yield token_ctor.Word(
+                w if auto_uppercase and t.txt not in PREFER_LOWERCASE else t.txt,
+                m,
+                token=t,
+            )
         else:
             # Already have a meaning (most likely from an abbreviation that the
             # tokenizer has recognized)
@@ -1261,7 +1264,7 @@ def parse_phrases_2(
                 # If wrd (without following period) is longer than
                 # middle name abbrevs such as "th", "kr" or "f"
                 # or not a foreign middle name (like "al", "der", "van")
-                if (
+                elif (
                     len(wrd.rstrip(".")) > 2 or wrd[0].islower()
                 ) and wrd not in FOREIGN_MIDDLE_NAME_SET:
                     return None

--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -510,7 +510,7 @@ MIDDLE_NAME_ABBREVS: FrozenSet[str] = frozenset(
     )
 )
 
-# Not name abbreviations if not followed by period
+# Not name abbreviations if not followed by period or surname
 NOT_NAME_ABBREVS: FrozenSet[str] = frozenset(("á", "í"))
 
 # Words which should probably be lowercase

--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -1228,18 +1228,18 @@ def parse_phrases_2(
             ) -> Optional[List[PersonNameTuple]]:
                 """ Check for given name or middle abbreviation """
                 gnames = given_names(tok)
+                wrd = tok.txt
                 if gnames is not None:
-                    if tok.txt in BOTH_GIVEN_AND_FAMILY_NAMES:
+                    if wrd in BOTH_GIVEN_AND_FAMILY_NAMES:
                         # For instance "Hafstein" which can be both a given
                         # name and a family name: prepend the family name as
                         # an genderless and caseless option to the list
                         gnames = [
-                            PersonNameTuple(name=tok.txt, gender=None, case=None)
+                            PersonNameTuple(name=wrd, gender=None, case=None)
                         ] + gnames
                     return gnames
                 if tok.kind != TOK.WORD:
                     return None
-                wrd = tok.txt
                 if len(wrd) > 2 or wrd[0].islower():
                     if wrd not in FOREIGN_MIDDLE_NAME_SET:
                         # Accept "Thomas de Broglie", "Ruud van Nistelrooy"

--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -1333,12 +1333,11 @@ def parse_phrases_2(
                                 next_token = next_token.concatenate(token_deque.popleft())
                                 ntxt = next_token.txt
 
-                            else:
-                                if ntxt in NOT_NAME_ABBREVS and not surnames(token_deque[0]):
-                                    # Next token is common word (such as "á", "í")
-                                    # and should only be considered a middle name
-                                    # if next word is a surname
-                                    break
+                            elif ntxt in NOT_NAME_ABBREVS and not surnames(token_deque[0]):
+                                # Next token is common word (such as "á", "í")
+                                # and should only be considered a middle name
+                                # if next word is a surname
+                                break
 
                     # Deal with wrong sentence end/begin (S_END/S_BEGIN) tokens
                     # that sometimes appear in middle of sentence
@@ -1439,13 +1438,10 @@ def parse_phrases_2(
                     # if so, add it to the person names we've already found
                     while unknown_surname(next_token):
                         ntxt = next_token.txt
+
                         if auto_uppercase and ntxt.islower():
-                            if ntxt in NOT_NAME_ABBREVS:
-                                # Don't interpret as middle name abbreviation
-                                break
-                            # Make sure that surnames are capitalized
-                            # if we are auto-capitalizing
                             ntxt = ntxt.capitalize()
+
                         for ix, p in enumerate(gn):
                             gn[ix] = PersonNameTuple(
                                 name=p.name + " " + ntxt, gender=p.gender, case=p.case,

--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -415,7 +415,7 @@ ENTITY_MIDDLE_NAME_SET: FrozenSet[str] = frozenset(
     ("in", "a", "an", "for", "and", "the", "for", "on", "of")
 )
 
-SENTENCE_END_START_TOKENS: FrozenSet[int] = frozenset((TOK.S_END, TOK.S_BEGIN))
+SENTENCE_DELIMITER_TOKENS: FrozenSet[int] = frozenset((TOK.S_END, TOK.S_BEGIN))
 
 # Given names that can also be family names (and thus gender- and caseless as such)
 BOTH_GIVEN_AND_FAMILY_NAMES: FrozenSet[str] = frozenset(("Hafstein",))
@@ -1323,7 +1323,7 @@ def parse_phrases_2(
                                 # Remove sentence end/start tokens
                                 while (
                                     next_next_token.punctuation == "."
-                                    or next_next_token.kind in SENTENCE_END_START_TOKENS
+                                    or next_next_token.kind in SENTENCE_DELIMITER_TOKENS
                                 ):
                                     next_next_token = next(token_stream)
                             except StopIteration:

--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -1221,12 +1221,9 @@ def parse_phrases_2(
                 """ Check for unknown (non-Icelandic) surnames """
                 # Accept (most) upper case words as a surnames
                 if auto_uppercase:
-                    if tok.txt in MIDDLE_NAME_ABBREVS:
-                        # We accept 'th', 'kr' and single-letter lowercase
-                        # abbrevs as surnames if auto-uppercasing
-                        return True
                     if tok.txt and not tok.val:
                         # Looks like an unknown word: accept it as a surname
+                        # (might be a foreign name)
                         return True
                 if tok.kind != TOK.WORD or not tok.txt[0].isupper():
                     # Must start with capital letter
@@ -1259,13 +1256,16 @@ def parse_phrases_2(
                     return None
                 if auto_uppercase and wrd in MIDDLE_NAME_ABBREVS:
                     wrd = wrd.capitalize()
+                # If wrd is longer than middle name abbrevs (possibly with following period)
+                # such as "th.", "kr" or "f."
+                # or not a foreign middle name (like "al", "der", "van")
                 if len(wrd) > 3 or (
                     wrd[0].islower() and wrd not in FOREIGN_MIDDLE_NAME_SET
                 ):
-                    # Accept "Thomas de Broglie", "Ruud van Nistelrooy"
                     return None
-                # One or two letters (possibly with following period), capitalized:
+                # One or two letters (possibly with following period):
                 # accept as middle name abbrev, all genders and cases possible
+                # Also accept lowercase foreign middle names ("Thomas de Broglie", "Ruud van Nistelrooy")
                 return [PersonNameTuple(name=wrd, gender=None, case=None)]
 
             def compatible(pn: PersonNameTuple, npn: PersonNameTuple) -> bool:

--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -415,7 +415,7 @@ ENTITY_MIDDLE_NAME_SET: FrozenSet[str] = frozenset(
     ("in", "a", "an", "for", "and", "the", "for", "on", "of")
 )
 
-SENTENCE_END_START_TOKENS: FrozenSet[str] = frozenset((TOK.S_END, TOK.S_BEGIN))
+SENTENCE_END_START_TOKENS: FrozenSet[int] = frozenset((TOK.S_END, TOK.S_BEGIN))
 
 # Given names that can also be family names (and thus gender- and caseless as such)
 BOTH_GIVEN_AND_FAMILY_NAMES: FrozenSet[str] = frozenset(("Hafstein",))

--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -1062,7 +1062,7 @@ def parse_phrases_2(
         while True:
             next_token = (
                 following_tokens.popleft()
-                if len(following_tokens)
+                if following_tokens
                 else next(token_stream)
             )
             # Make the lookahead checks we're interested in
@@ -1366,7 +1366,7 @@ def parse_phrases_2(
                     namespan += next_token.original or ""
                     next_token = (
                         following_tokens.popleft()
-                        if len(following_tokens)
+                        if following_tokens
                         else next(token_stream)
                     )
 
@@ -1442,7 +1442,7 @@ def parse_phrases_2(
                         namespan += next_token.original or ""
                         next_token = (
                             following_tokens.popleft()
-                            if len(following_tokens)
+                            if following_tokens
                             else next(token_stream)
                         )
                         # Assume we now have a patronym

--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -192,6 +192,8 @@ NOT_NAME_AT_SENTENCE_START: FrozenSet[str] = frozenset(
         "Ljót",
         "Ljóti",
         "Ljóts",
+        "Mikill",
+        "Mikil",
     )
 )
 

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -1839,6 +1839,10 @@ def test_names(r):
     s = r.parse_single("Við hringdum í Baldvin Kr.")
     assert "Baldvin Kr." in s.tree.persons
 
+    s = r.parse("Við vitum ekki hvaða hesta Jón á. Hann hefur verið bóndi í langan tíma.")
+    assert len(s["sentences"]) == 2
+    assert "Jón" in s["sentences"][0].tree.persons
+
 
 def test_prepositions(r):
     s = r.parse_single("Ég fór niðrá bryggjuna.")

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -1813,7 +1813,11 @@ def test_names(r):
 
     s = r.parse_single("Ég sá Jónínu Á í svifflugi.")
     assert "Jónína Á" in s.tree.persons
+    s = r.parse_single("Ég sá Jónínu Á á Eyrarbakka.")
+    assert "Jónína Á" in s.tree.persons
     s = r.parse_single("Við mættum Þorsteini Í í fallhlífarstökki.")
+    assert "Þorsteinn Í" in s.tree.persons
+    s = r.parse_single("Við mættum Þorsteini Í á Borðeyri.")
     assert "Þorsteinn Í" in s.tree.persons
     s = r.parse_single("Halldór Á Í Jónsson er stór maður")
     assert "Halldór Á Í Jónsson" in s.tree.persons
@@ -1827,6 +1831,13 @@ def test_names(r):
     assert "Hafsteinn B Guðmundsson" in s.tree.persons
     s = r.parse_single("Við hringdum í Hafstein B. Guðmundsson")
     assert "Hafsteinn B. Guðmundsson" in s.tree.persons
+
+    s = r.parse_single("Við hringdum í Guðna Th.")
+    assert "Guðni Th." in s.tree.persons
+    s = r.parse_single("Við hringdum í Baldvin Kr. Magnússon")
+    assert "Baldvin Kr. Magnússon" in s.tree.persons
+    s = r.parse_single("Við hringdum í Baldvin Kr.")
+    assert "Baldvin Kr." in s.tree.persons
 
 
 def test_prepositions(r):

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -1791,8 +1791,7 @@ def test_names(r):
     assert s.tree.nouns == ["sýning", "bíó", "þriðjudagskvöld"]
     s = r.parse_single("Ruud van Nistelrooy og Thomas de Broglie komu í heimsókn.")
     assert "Thomas de Broglie" in s.tree.persons
-    # "Ruud van Nistelrooy" gets interpreted as an entity
-    # assert "Ruud van Nistelrooy" in s.tree.persons
+    assert "Ruud van Nistelrooy" in s.tree.entities
 
     s = r.parse_single("Tómas Í. Guðmundsson og Guðfinna Á. Ákadóttir komu í heimsókn.")
     assert (

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -1789,6 +1789,45 @@ def test_names(r):
     assert s.tree is not None
     assert s.tree.persons == []
     assert s.tree.nouns == ["sýning", "bíó", "þriðjudagskvöld"]
+    s = r.parse_single("Ruud van Nistelrooy og Thomas de Broglie komu í heimsókn.")
+    assert "Thomas de Broglie" in s.tree.persons
+    # "Ruud van Nistelrooy" gets interpreted as an entity
+    # assert "Ruud van Nistelrooy" in s.tree.persons
+
+    s = r.parse_single("Tómas Í. Guðmundsson og Guðfinna Á. Ákadóttir komu í heimsókn.")
+    assert (
+        "Tómas Í. Guðmundsson" in s.tree.persons
+        and "Guðfinna Á. Ákadóttir" in s.tree.persons
+    )
+
+    s = r.parse_single("Tómas Í. og Guðfinna Á. komu í heimsókn.")
+    assert "Tómas Í." in s.tree.persons and "Guðfinna Á." in s.tree.persons
+
+    s = r.parse_single("Tómas Í Guðmundsson og Guðfinna Á Ákadóttir komu í heimsókn.")
+    assert (
+        "Tómas Í Guðmundsson" in s.tree.persons
+        and "Guðfinna Á Ákadóttir" in s.tree.persons
+    )
+
+    s = r.parse_single("Tómas Í og Guðfinna Á komu í heimsókn.")
+    assert "Tómas Í" in s.tree.persons and "Guðfinna Á" in s.tree.persons
+
+    s = r.parse_single("Ég sá Jónínu Á í svifflugi.")
+    assert "Jónína Á" in s.tree.persons
+    s = r.parse_single("Við mættum Þorsteini Í í fallhlífarstökki.")
+    assert "Þorsteinn Í" in s.tree.persons
+    s = r.parse_single("Halldór Á Í Jónsson er stór maður")
+    assert "Halldór Á Í Jónsson" in s.tree.persons
+    s = r.parse_single("Halldór Á. Í. Jónsson er stór maður")
+    assert "Halldór Á. Í. Jónsson" in s.tree.persons
+    s = r.parse_single("Við hringdum í Hafstein Í.")
+    assert "Hafsteinn Í." in s.tree.persons
+    s = r.parse_single("Við hringdum í Hafstein Á.")
+    assert "Hafsteinn Á." in s.tree.persons
+    s = r.parse_single("Við hringdum í Hafstein B Guðmundsson")
+    assert "Hafsteinn B Guðmundsson" in s.tree.persons
+    s = r.parse_single("Við hringdum í Hafstein B. Guðmundsson")
+    assert "Hafsteinn B. Guðmundsson" in s.tree.persons
 
 
 def test_prepositions(r):

--- a/test/test_reynir.py
+++ b/test/test_reynir.py
@@ -317,27 +317,42 @@ def test_auto_uppercase():
 
     for abbr in MIDDLE_NAME_ABBREVS:
         if abbr not in NOT_NAME_ABBREVS:
-            # Skip abbreviations that aren't
-            # middle names without a following period
+            # No period, no extra tokens
             s = g.parse_single(f"hér er jón {abbr}")
             assert (
                 detokenize(s.tokens) == f"hér er Jón {abbr.capitalize()}"
             )
             assert f"Jón {abbr.capitalize()}" in s.tree.persons
 
-            s = g.parse_single(f"hér er jón {abbr} guðnason")
+            # No period, extra tokens
+            s = g.parse_single(f"við jón {abbr} erum góðir vinir")
             assert (
-                detokenize(s.tokens) == f"hér er Jón {abbr.capitalize()} Guðnason"
+                detokenize(s.tokens) == f"við Jón {abbr.capitalize()} erum góðir vinir"
             )
-            assert f"Jón {abbr.capitalize()} Guðnason" in s.tree.persons
+            assert f"Jón {abbr.capitalize()}" in s.tree.persons
 
-        # Middle names with following period
+        # No period, surname
+        s = g.parse_single(f"hér er jón {abbr} guðnason")
+        assert (
+            detokenize(s.tokens) == f"hér er Jón {abbr.capitalize()} Guðnason"
+        )
+        assert f"Jón {abbr.capitalize()} Guðnason" in s.tree.persons
+
+        # With period, no extra tokens
         s = g.parse_single(f"hér er jón {abbr}.")
         assert (
             detokenize(s.tokens) == f"hér er Jón {abbr.capitalize()}."
         )
         assert f"Jón {abbr.capitalize()}." in s.tree.persons
 
+        # With period, extra tokens
+        s = g.parse_single(f"við jón {abbr}. erum góðir vinir")
+        assert (
+            detokenize(s.tokens) == f"við Jón {abbr.capitalize()}. erum góðir vinir"
+        )
+        assert f"Jón {abbr.capitalize()}." in s.tree.persons
+
+        # With period, surname
         s = g.parse_single(f"hér er jón {abbr}. guðnason")
         assert (
             detokenize(s.tokens) == f"hér er Jón {abbr.capitalize()}. Guðnason"
@@ -388,9 +403,9 @@ def test_auto_uppercase():
         and "Hámundur Á. Guðmundsson" in s.tree.persons
     )
 
-    # s = g.parse_single("hver er guðmundur í hámundarson, sonur hámundar á guðmundssonar")
-    # assert detokenize(s.tokens) == "hver er Guðmundur í Hámundarson, sonur Hámundar á Guðmundssonar"
-    # assert "Guðmundur" in s.tree.persons and "Hámundur" in s.tree.persons
+    s = g.parse_single("hver er guðmundur í hámundarson, sonur hámundar á guðmundssonar")
+    assert detokenize(s.tokens) == "hver er Guðmundur Í Hámundarson, sonur Hámundar Á Guðmundssonar"
+    assert "Guðmundur Í Hámundarson" in s.tree.persons and "Hámundur Á Guðmundsson" in s.tree.persons
 
     s = g.parse_single(
         "ég hitti loft á bíldudal, blæ á seyðisfirði og skúla í keflavík"
@@ -455,6 +470,10 @@ def test_auto_uppercase():
     s = g.parse_single("hann dagur í. dagsson er forkunnarfagur")
     assert detokenize(s.tokens) == "hann Dagur Í. Dagsson er forkunnarfagur"
     assert "Dagur Í. Dagsson" in s.tree.persons
+
+    s = g.parse_single("hann dagur í dagsson er forkunnarfagur")
+    assert detokenize(s.tokens) == "hann Dagur Í Dagsson er forkunnarfagur"
+    assert "Dagur Í Dagsson" in s.tree.persons
 
     s = g.parse_single("guðmundur er bóndi á stöpum og mjólkar kýr")
     assert detokenize(s.tokens) == "Guðmundur er bóndi á Stöpum og mjólkar kýr"

--- a/test/test_reynir.py
+++ b/test/test_reynir.py
@@ -331,22 +331,24 @@ def test_auto_uppercase():
     assert "Eliza Reid" in s.tree.persons
 
     s = g.parse_single("hver er hæð jóns")
-    # FIXME: 'hæð' gets capitalized
-    # assert detokenize(s.tokens) == "hver er hæð Jóns"
+    assert detokenize(s.tokens) == "hver er hæð Jóns"
     assert "Jón" in s.tree.persons
 
     s = g.parse_single("hver er hæð sólar í dag í reykjavík")
     assert "Í" not in detokenize(s.tokens)
     assert "Sólar Í Dag Í Reykjavík" not in s.tree.persons
 
-    # FIXME: "Á" gets interpreted as the place name
-    # s = g.parse_single("hver er guðmundur í. hámundarson, sonur hámundar á. guðmundssonar")
-    # assert detokenize(s.tokens) == "hver er Guðmundur Í. Hámundarson, sonur Hámundar Á. Guðmundssonar"
-    # assert "Guðmundur Í. Hámundarson" in s.tree.persons and "Hámundur Á. Guðmundsson" in s.tree.persons
+    s = g.parse_single("hver er guðmundur í. hámundarson, sonur hámundar á. guðmundssonar")
+    assert detokenize(s.tokens) == "hver er Guðmundur Í. Hámundarson, sonur Hámundar Á. Guðmundssonar"
+    assert "Guðmundur Í. Hámundarson" in s.tree.persons and "Hámundur Á. Guðmundsson" in s.tree.persons
 
     # s = g.parse_single("hver er guðmundur í hámundarson, sonur hámundar á guðmundssonar")
-    # assert detokenize(s.tokens) == "hver er Guðmundur í Hámundarson, sonur Hámundar Á Guðmundssonar"
+    # assert detokenize(s.tokens) == "hver er Guðmundur í Hámundarson, sonur Hámundar á Guðmundssonar"
     # assert "Guðmundur" in s.tree.persons and "Hámundur" in s.tree.persons
+
+    s = g.parse_single("ég hitti loft á bíldudal, blæ á seyðisfirði og skúla í keflavík")
+    assert detokenize(s.tokens) == "ég hitti Loft á Bíldudal, Blæ á Seyðisfirði og Skúla í Keflavík"
+    assert "Loftur" in s.tree.persons and "Blær" in s.tree.persons and "Skúli" in s.tree.persons
 
     s = g.parse_single("hver er lofthæna s melkorkudóttir")
     assert detokenize(s.tokens) == "hver er Lofthæna S Melkorkudóttir"
@@ -408,23 +410,20 @@ def test_auto_uppercase():
     assert "Dagur Í. Dagsson" in s.tree.persons
 
     s = g.parse_single("guðmundur er bóndi á stöpum og mjólkar kýr")
-    # FIXME: "bóndi" and "á" get interpreted as placenames
-    # assert detokenize(s.tokens) == "Guðmundur er bóndi á Stöpum og mjólkar kýr"
+    assert detokenize(s.tokens) == "Guðmundur er bóndi á Stöpum og mjólkar kýr"
     assert "Guðmundur" in s.tree.persons and "Guðmundur Er Bóndi" not in s.tree.persons
 
     s = g.parse_single("hvað er gummi í mörgum íþróttafélögum")
     assert detokenize(s.tokens) == "hvað er Gummi í mörgum íþróttafélögum"
     assert "Gummi" in s.tree.persons
 
-    # FIXME: "á" is interpreted as a placename
-    # s = g.parse_single("gunnar á hlíðarenda var vinur njáls á bergþórshvoli")
-    # assert detokenize(s.tokens) == "Gunnar á Hlíðarenda var vinur Njáls á Bergþórshvoli"
-    # assert "Gunnar" in s.tree.persons and "Njáll" in s.tree.persons
+    s = g.parse_single("gunnar á hlíðarenda var vinur njáls á bergþórshvoli")
+    assert detokenize(s.tokens) == "Gunnar á Hlíðarenda var vinur Njáls á Bergþórshvoli"
+    assert "Gunnar" in s.tree.persons and "Njáll" in s.tree.persons
 
-    # Same issue with "á"
-    # s = g.parse_single("ég hitti ástbjörn í hverri viku og gunnu á miðvikudögum")
-    # assert detokenize(s.tokens) == "ég hitti Ástbjörn í hverri viku og Gunnu á miðvikudögum"
-    # assert "Ástbjörn" in s.tree.persons and "Gunna" in s.tree.persons
+    s = g.parse_single("ég hitti ástbjörn í hverri viku og gunnu á miðvikudögum")
+    assert detokenize(s.tokens) == "ég hitti Ástbjörn í hverri viku og Gunnu á miðvikudögum"
+    assert "Ástbjörn" in s.tree.persons and "Gunna" in s.tree.persons
 
 
 def test_compounds():

--- a/test/test_reynir.py
+++ b/test/test_reynir.py
@@ -416,13 +416,15 @@ def test_auto_uppercase():
     assert detokenize(s.tokens) == "hvað er Gummi í mörgum íþróttafélögum"
     assert "Gummi" in s.tree.persons
 
-    s = g.parse_single("gunnar á hlíðarenda var vinur njáls á bergþórshvoli")
-    assert detokenize(s.tokens) == "Gunnar á Hlíðarenda var vinur Njáls á Bergþórshvoli"
-    assert "Gunnar" in s.tree.persons and "Njáll" in s.tree.persons
+    # FIXME: "á" is interpreted as a placename
+    # s = g.parse_single("gunnar á hlíðarenda var vinur njáls á bergþórshvoli")
+    # assert detokenize(s.tokens) == "Gunnar á Hlíðarenda var vinur Njáls á Bergþórshvoli"
+    # assert "Gunnar" in s.tree.persons and "Njáll" in s.tree.persons
 
-    s = g.parse_single("ég hitti ástbjörn í hverri viku og gunnu á miðvikudögum")
-    assert detokenize(s.tokens) == "ég hitti Ástbjörn í hverri viku og Gunnu á miðvikudögum"
-    assert "Ástbjörn" in s.tree.persons and "Gunna" in s.tree.persons
+    # Same issue with "á"
+    # s = g.parse_single("ég hitti ástbjörn í hverri viku og gunnu á miðvikudögum")
+    # assert detokenize(s.tokens) == "ég hitti Ástbjörn í hverri viku og Gunnu á miðvikudögum"
+    # assert "Ástbjörn" in s.tree.persons and "Gunna" in s.tree.persons
 
 
 def test_compounds():

--- a/test/test_reynir.py
+++ b/test/test_reynir.py
@@ -338,17 +338,34 @@ def test_auto_uppercase():
     assert "Í" not in detokenize(s.tokens)
     assert "Sólar Í Dag Í Reykjavík" not in s.tree.persons
 
-    s = g.parse_single("hver er guðmundur í. hámundarson, sonur hámundar á. guðmundssonar")
-    assert detokenize(s.tokens) == "hver er Guðmundur Í. Hámundarson, sonur Hámundar Á. Guðmundssonar"
-    assert "Guðmundur Í. Hámundarson" in s.tree.persons and "Hámundur Á. Guðmundsson" in s.tree.persons
+    s = g.parse_single(
+        "hver er guðmundur í. hámundarson, sonur hámundar á. guðmundssonar"
+    )
+    assert (
+        detokenize(s.tokens)
+        == "hver er Guðmundur Í. Hámundarson, sonur Hámundar Á. Guðmundssonar"
+    )
+    assert (
+        "Guðmundur Í. Hámundarson" in s.tree.persons
+        and "Hámundur Á. Guðmundsson" in s.tree.persons
+    )
 
     # s = g.parse_single("hver er guðmundur í hámundarson, sonur hámundar á guðmundssonar")
     # assert detokenize(s.tokens) == "hver er Guðmundur í Hámundarson, sonur Hámundar á Guðmundssonar"
     # assert "Guðmundur" in s.tree.persons and "Hámundur" in s.tree.persons
 
-    s = g.parse_single("ég hitti loft á bíldudal, blæ á seyðisfirði og skúla í keflavík")
-    assert detokenize(s.tokens) == "ég hitti Loft á Bíldudal, Blæ á Seyðisfirði og Skúla í Keflavík"
-    assert "Loftur" in s.tree.persons and "Blær" in s.tree.persons and "Skúli" in s.tree.persons
+    s = g.parse_single(
+        "ég hitti loft á bíldudal, blæ á seyðisfirði og skúla í keflavík"
+    )
+    assert (
+        detokenize(s.tokens)
+        == "ég hitti Loft á Bíldudal, Blæ á Seyðisfirði og Skúla í Keflavík"
+    )
+    assert (
+        "Loftur" in s.tree.persons
+        and "Blær" in s.tree.persons
+        and "Skúli" in s.tree.persons
+    )
 
     s = g.parse_single("hver er lofthæna s melkorkudóttir")
     assert detokenize(s.tokens) == "hver er Lofthæna S Melkorkudóttir"
@@ -422,7 +439,10 @@ def test_auto_uppercase():
     assert "Gunnar" in s.tree.persons and "Njáll" in s.tree.persons
 
     s = g.parse_single("ég hitti ástbjörn í hverri viku og gunnu á miðvikudögum")
-    assert detokenize(s.tokens) == "ég hitti Ástbjörn í hverri viku og Gunnu á miðvikudögum"
+    assert (
+        detokenize(s.tokens)
+        == "ég hitti Ástbjörn í hverri viku og Gunnu á miðvikudögum"
+    )
     assert "Ástbjörn" in s.tree.persons and "Gunna" in s.tree.persons
 
 

--- a/test/test_reynir.py
+++ b/test/test_reynir.py
@@ -317,12 +317,112 @@ def test_auto_uppercase():
     s = g.parse_single("hver er guðni th jóhannesson")
     assert detokenize(s.tokens) == "hver er Guðni Th Jóhannesson"
     assert "Guðni Th Jóhannesson" in s.tree.persons
+
+    s = g.parse_single("hver er guðni th. jóhannesson")
+    assert detokenize(s.tokens) == "hver er Guðni Th. Jóhannesson"
+    assert "Guðni Th. Jóhannesson" in s.tree.persons
+
     s = g.parse_single("hver er gunnar thoroddsen")
     assert detokenize(s.tokens) == "hver er Gunnar Thoroddsen"
     assert "Gunnar Thoroddsen" in s.tree.persons
+
     s = g.parse_single("hver er eliza reid")
     assert detokenize(s.tokens) == "hver er Eliza Reid"
     assert "Eliza Reid" in s.tree.persons
+
+    s = g.parse_single("hver er hæð jóns")
+    # FIXME: 'hæð' gets capitalized
+    # assert detokenize(s.tokens) == "hver er hæð Jóns"
+    assert "Jón" in s.tree.persons
+
+    s = g.parse_single("hver er hæð sólar í dag í reykjavík")
+    assert "Í" not in detokenize(s.tokens)
+    assert "Sólar Í Dag Í Reykjavík" not in s.tree.persons
+
+    # FIXME: "Á" gets interpreted as the place name
+    # s = g.parse_single("hver er guðmundur í. hámundarson, sonur hámundar á. guðmundssonar")
+    # assert detokenize(s.tokens) == "hver er Guðmundur Í. Hámundarson, sonur Hámundar Á. Guðmundssonar"
+    # assert "Guðmundur Í. Hámundarson" in s.tree.persons and "Hámundur Á. Guðmundsson" in s.tree.persons
+
+    # s = g.parse_single("hver er guðmundur í hámundarson, sonur hámundar á guðmundssonar")
+    # assert detokenize(s.tokens) == "hver er Guðmundur í Hámundarson, sonur Hámundar Á Guðmundssonar"
+    # assert "Guðmundur" in s.tree.persons and "Hámundur" in s.tree.persons
+
+    s = g.parse_single("hver er lofthæna s melkorkudóttir")
+    assert detokenize(s.tokens) == "hver er Lofthæna S Melkorkudóttir"
+    assert "Lofthæna S Melkorkudóttir" in s.tree.persons
+
+    s = g.parse_single("katrín jakobs hitti justin p. j. trudeau um daginn")
+    assert detokenize(s.tokens) == "Katrín Jakobs hitti Justin P. J. Trudeau um daginn"
+    assert (
+        "Katrín Jakobs" in s.tree.persons and "Justin P. J. Trudeau" in s.tree.persons
+    )
+
+    s = g.parse_single("katrín jakobsdóttir hitti justin p j trudeau um daginn")
+    assert (
+        detokenize(s.tokens) == "Katrín Jakobsdóttir hitti Justin P J Trudeau um daginn"
+    )
+    assert (
+        "Katrín Jakobsdóttir" in s.tree.persons
+        and "Justin P J Trudeau" in s.tree.persons
+    )
+
+    s = g.parse_single("rætt var við dag b eggertsson, borgarstjóra reykjavíkur")
+    assert (
+        detokenize(s.tokens)
+        == "rætt var við Dag B Eggertsson, borgarstjóra Reykjavíkur"
+    )
+    assert "Dagur B Eggertsson" in s.tree.persons
+
+    s = g.parse_single("rætt var við dag b. eggertsson, borgarstjóra reykjavíkur")
+    assert (
+        detokenize(s.tokens)
+        == "rætt var við Dag B. Eggertsson, borgarstjóra Reykjavíkur"
+    )
+    assert "Dagur B. Eggertsson" in s.tree.persons
+
+    s = g.parse_single("hver er guðrún í.")
+    assert detokenize(s.tokens) == "hver er Guðrún Í."
+    assert "Guðrún Í." in s.tree.persons
+
+    s = g.parse_single("hver er dagur s")
+    assert detokenize(s.tokens) == "hver er Dagur S"
+    assert "Dagur S" in s.tree.persons
+
+    s = g.parse_single(
+        "úrsúla von der leyen (fædd 8. október 1958) er þýskur stjórnmálamaður "
+        "og núverandi forseti framkvæmdastjórnar evrópusambandsins"
+    )
+    assert (
+        detokenize(s.tokens)
+        == "Úrsúla von der Leyen (fædd 8. október 1958) er þýskur stjórnmálamaður "
+        "og núverandi forseti framkvæmdastjórnar Evrópusambandsins"
+    )
+    assert "Úrsúla von der Leyen" in s.tree.persons
+
+    s = g.parse_single("það er fallegur dagur í dag")
+    assert "Í" not in detokenize(s.tokens)
+
+    s = g.parse_single("hann dagur í. dagsson er forkunnarfagur")
+    assert detokenize(s.tokens) == "hann Dagur Í. Dagsson er forkunnarfagur"
+    assert "Dagur Í. Dagsson" in s.tree.persons
+
+    s = g.parse_single("guðmundur er bóndi á stöpum og mjólkar kýr")
+    # FIXME: "bóndi" and "á" get interpreted as placenames
+    # assert detokenize(s.tokens) == "Guðmundur er bóndi á Stöpum og mjólkar kýr"
+    assert "Guðmundur" in s.tree.persons and "Guðmundur Er Bóndi" not in s.tree.persons
+
+    s = g.parse_single("hvað er gummi í mörgum íþróttafélögum")
+    assert detokenize(s.tokens) == "hvað er Gummi í mörgum íþróttafélögum"
+    assert "Gummi" in s.tree.persons
+
+    s = g.parse_single("gunnar á hlíðarenda var vinur njáls á bergþórshvoli")
+    assert detokenize(s.tokens) == "Gunnar á Hlíðarenda var vinur Njáls á Bergþórshvoli"
+    assert "Gunnar" in s.tree.persons and "Njáll" in s.tree.persons
+
+    s = g.parse_single("ég hitti ástbjörn í hverri viku og gunnu á miðvikudögum")
+    assert detokenize(s.tokens) == "ég hitti Ástbjörn í hverri viku og Gunnu á miðvikudögum"
+    assert "Ástbjörn" in s.tree.persons and "Gunna" in s.tree.persons
 
 
 def test_compounds():


### PR DESCRIPTION
Changes to middle name abbreviation functionality when auto_uppercasing.

Interprets words in `MIDDLE_NAME_ABBREV` as middle name abbreviations (adding them to the name) and words in `NOT_NAME_ABBREVS` as abbreviations **only if they are followed by a period (".")**.

Fixes #42 (at least partially, 'sólar' and 'dag' are still capitalized along with "hæð', but 'sólar í dag í reykjavík' doesn't get interpreted as a single name).