### PR TITLE
Auto uppercase (small fix)

### DIFF
--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -629,13 +629,14 @@ def annotate(
         # This is a word token
         w = t.txt
         if not t.val:
-            # Look up word in BIN database
+            # Look up word in BÍN database
             # If word is found in PREFER_LOWERCASE we skip searching uppercase meanings
             # (if auto_uppercase is True)
             w, m = db.lookup_g(
-                w, at_sentence_start, auto_uppercase and not w in PREFER_LOWERCASE
+                w, at_sentence_start, auto_uppercase and w not in PREFER_LOWERCASE
             )
             if not m:
+                # No meaning found in BÍN
                 # Check exceptional cases involving hyphens
                 w = t.txt
                 if w[0] in COMPOSITE_HYPHENS:
@@ -668,8 +669,6 @@ def annotate(
                         w_new, m = db.lookup_g(
                             "".join(parts), at_sentence_start, auto_uppercase
                         )
-                    else:
-                        w_new = ""  # Included to silence warning about unbound variable
                     if m:
                         # Found without hyphens: use that word form
                         m = [

--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -514,7 +514,17 @@ MIDDLE_NAME_ABBREVS: FrozenSet[str] = frozenset(
 NOT_NAME_ABBREVS: FrozenSet[str] = frozenset(("á", "í"))
 
 # Words which should probably be lowercase
-PREFER_LOWERCASE: FrozenSet[str] = frozenset(("á", "bóndi", "ganga", "hæð"))
+PREFER_LOWERCASE: FrozenSet[str] = frozenset(
+    (
+        "á",
+        "bóndi",
+        "frá",
+        "ganga",
+        "hæð",
+        "mikil",
+        "mikill",
+    )
+)
 
 
 def load_token(*args: Any) -> Tuple[int, str, ValType]:
@@ -620,7 +630,11 @@ def annotate(
         w = t.txt
         if not t.val:
             # Look up word in BIN database
-            w, m = db.lookup_g(w, at_sentence_start, auto_uppercase)
+            # If word is found in PREFER_LOWERCASE we skip searching uppercase meanings
+            # (if auto_uppercase is True)
+            w, m = db.lookup_g(
+                w, at_sentence_start, auto_uppercase and not w in PREFER_LOWERCASE
+            )
             if not m:
                 # Check exceptional cases involving hyphens
                 w = t.txt
@@ -698,7 +712,7 @@ def annotate(
 
             # Yield a word tuple with meanings
             yield token_ctor.Word(
-                w if auto_uppercase and t.txt not in PREFER_LOWERCASE else t.txt,
+                w if auto_uppercase else t.txt,
                 m,
                 token=t,
             )

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -1875,15 +1875,15 @@ def test_personally(r):
         == "S0 S-MAIN IP NP-SUBJ pfn_et_p1_þgf ao /NP-SUBJ VP VP so_subj_op_þgf_et_fh_gm_þt /VP "
         "NP fn_et_hk_nf /NP NP-PRD eo lo_et_hk_nf_sb /NP-PRD /VP /IP /S-MAIN p /S0"
     )
-    s = r.parse_single("Þetta mál varðar þig persónulega.")
+    s = r.parse_single("Þessi samningur varðar þig persónulega.")
     assert s.tree is not None
     assert (
         s.tree.flat_with_all_variants
-        == "S0 S-MAIN IP NP-SUBJ fn_et_hk_nf no_et_hk_nf /NP-SUBJ VP VP "
+        == "S0 S-MAIN IP NP-SUBJ fn_et_kk_nf no_et_kk_nf /NP-SUBJ VP VP "
         "so_1_þf_et_fh_gm_nt_p3 /VP NP-OBJ pfn_et_p2_þf ao /NP-OBJ /VP /IP /S-MAIN p /S0"
     ) or (
         s.tree.flat_with_all_variants
-        == "S0 S-MAIN IP NP-SUBJ fn_et_hk_nf no_et_hk_nf /NP-SUBJ VP VP "
+        == "S0 S-MAIN IP NP-SUBJ fn_et_kk_nf no_et_kk_nf /NP-SUBJ VP VP "
         "so_1_þf_subj_op_þf_et_fh_gm_nt /VP NP-OBJ pfn_et_p2_þf ao /NP-OBJ /VP /IP /S-MAIN p /S0"
     )
     s = r.parse_single("Þetta kom illa við þær persónulega.")


### PR DESCRIPTION
- Additions to PREFER_LOWERCASE (`Frár`, `Mikill`) 
- Uppercase meanings now aren't searched if word in PREFER_LOWERCASE.