### PR TITLE
Modernization

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,12 +24,11 @@ jobs:
     - name: Install GreynirEngine
       run: |
         python -m pip install uv
-        uv pip install --system pip wheel setuptools pytest
+        uv pip install --system wheel setuptools pytest ruff
         uv pip install --system -e .
     - name: Lint with ruff
       run: |
-        if [ "${{ matrix.python-version }}" == "3.9" ]; then uv pip install --system ruff; fi
-        if [ "${{ matrix.python-version }}" == "3.9" ]; then ruff check src/reynir; fi
+        ruff check src/reynir
     - name: Test with pytest
       run: |
         python -m pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.1", "pypy-3.9", "pypy-3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", '3.14.0-beta.4', "pypy-3.9", "pypy-3.10", "pypy-3.11"]
 
     steps:
     - uses: actions/checkout@v4
@@ -23,8 +23,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install GreynirEngine
       run: |
-        python -m pip install --upgrade pip wheel setuptools pytest
-        python -m pip install -e .
+        python -m pip install uv
+        uv pip install --system pip wheel setuptools pytest
+        uv pip install --system -e .
+    - name: Lint with ruff
+      run: |
+        if [ "${{ matrix.python-version }}" == "3.9" ]; then uv pip install --system ruff; fi
+        if [ "${{ matrix.python-version }}" == "3.9" ]; then ruff check src/reynir; fi
     - name: Test with pytest
       run: |
         python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dependencies = [
 
 [project.urls]
 Repository = "https://github.com/mideind/GreynirEngine"
+Homepage = "https://greynir.is"
+Documentation = "https://greynir.is/doc/"
+Issues = "https://github.com/mideind/GreynirEngine/issues"
 
 [project.optional-dependencies]
 # dev dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,9 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "cffi>=1.15.1",
-    "tokenizer>=3.4.5",
-    "islenska>=1.0.3",
+    "cffi>=1.17.1",
+    "tokenizer>=3.5.1",
+    "islenska>=1.0.4",
     "typing_extensions",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,11 +67,13 @@ reynir = ["py.typed"]
 
 [tool.ruff]
 line-length = 88
+
+[tool.ruff.lint]
 #lint.select = ["ALL"] # We use default rules for now
 # extend-select = ["E501"] # Complain about line length
 # Ignore specific rules
 # (we should aim to have these as few as possible)
-lint.ignore = [
+ignore = [
     "E731", # 'E731: Do not assign a lambda expression, use a def'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ include-package-data = true
 where = ["src"]
 
 [tool.setuptools.package-data]
-islenska = ["py.typed"]
+reynir = ["py.typed"]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,78 @@
+[build-system]
+requires = ["setuptools>=61.0", "cffi>=1.15.1"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "reynir"
+version = "3.5.8"
+description = "A natural language parser for Icelandic"
+authors = [{ name = "Miðeind ehf.", email = "mideind@mideind.is" }]
+maintainers = [{ name = "Miðeind ehf.", email = "mideind@mideind.is" }]
+readme = { file = "README.md", content-type = "text/markdown" }
+license = { text = "MIT License" }
+keywords = ["nlp", "parser", "icelandic"]
+classifiers = [
+    # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: Unix",
+    "Operating System :: POSIX",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS",
+    "Natural Language :: Icelandic",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Utilities",
+    "Topic :: Text Processing :: Linguistic",
+]
+requires-python = ">=3.9"
+dependencies = [
+    "cffi>=1.15.1",
+    "tokenizer>=3.4.5",
+    "islenska>=1.0.3",
+    "typing_extensions",
+]
+
+[project.urls]
+Repository = "https://github.com/mideind/GreynirEngine"
+
+[project.optional-dependencies]
+# dev dependencies
+dev = ["pytest"]
+
+# *** Configuration of tools ***
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+islenska = ["py.typed"]
+
+[tool.ruff]
+line-length = 88
+#lint.select = ["ALL"] # We use default rules for now
+# extend-select = ["E501"] # Complain about line length
+# Ignore specific rules
+# (we should aim to have these as few as possible)
+lint.ignore = [
+    "E731", # 'E731: Do not assign a lambda expression, use a def'
+]
+
+[tool.isort]
+# This forces these imports to placed at the top
+known_future_library = ["__future__", "typing", "typing_extensions"]
+line_length = 88

--- a/setup.py
+++ b/setup.py
@@ -1,105 +1,14 @@
 #!/usr/bin/env python3
 """
-    Greynir: Natural language processing for Icelandic
-
-    Setup.py
-
-    Copyright © 2023 Miðeind ehf.
-    Original Author: Vilhjálmur Þorsteinsson
-
-    This software is licensed under the MIT License:
-
-        Permission is hereby granted, free of charge, to any person
-        obtaining a copy of this software and associated documentation
-        files (the "Software"), to deal in the Software without restriction,
-        including without limitation the rights to use, copy, modify, merge,
-        publish, distribute, sublicense, and/or sell copies of the Software,
-        and to permit persons to whom the Software is furnished to do so,
-        subject to the following conditions:
-
-        The above copyright notice and this permission notice shall be
-        included in all copies or substantial portions of the Software.
-
-        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-        IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-        CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-        TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-        SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-    This module sets up the Greynir package. It uses the cffi_modules
-    parameter, available in recent versions of setuptools, to
-    automatically compile the eparser.cpp module to eparser.*.so/.pyd
-    and build the required CFFI Python wrapper via eparser_build.py.
-    The same applies to bin.cpp -> bin.*.so and bin_build.py.
-
-    Note that installing under PyPy >= 3.9 is supported (and recommended
-    for best performance).
-
+This file is retained for CFFI compilation.
+All package metadata is defined in pyproject.toml.
 """
 
-from glob import glob
-from os.path import basename, splitext
+from setuptools import setup
 
-from setuptools import find_packages
-from setuptools import setup  # type: ignore
-
-
-with open("README.md", "r", encoding="utf-8") as fh:
-    long_description = fh.read()
-
+# The cffi_modules and zip_safe settings are not yet supported in pyproject.toml
+# and must be defined here.
 setup(
-    name="reynir",
-    version="3.5.7",
-    license="MIT",
-    description="A natural language parser for Icelandic",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Miðeind ehf",
-    author_email="mideind@mideind.is",
-    url="https://github.com/mideind/GreynirEngine",
-    packages=find_packages("src"),
-    package_dir={"": "src"},
-    py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
-    package_data={"reynir": ["py.typed"]},
-    include_package_data=True,
     zip_safe=True,
-    classifiers=[
-        # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: Unix",
-        "Operating System :: POSIX",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: MacOS",
-        "Natural Language :: Icelandic",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Utilities",
-        "Topic :: Text Processing :: Linguistic",
-    ],
-    keywords=["nlp", "parser", "icelandic"],
-    # Note: cffi 1.15.1 is the version built into PyPy 3.9.
-    # Do not specify a higher version as that would prevent installation on PyPy 3.9,
-    # unless you know what you're doing.
-    setup_requires=["cffi>=1.15.1"],
-    install_requires=[
-        "cffi>=1.15.1",
-        "tokenizer>=3.4.5",
-        "islenska>=1.0.3",
-        "typing_extensions",
-    ],
     cffi_modules=["src/reynir/eparser_build.py:ffibuilder"],
 )

--- a/src/reynir/binparser.py
+++ b/src/reynir/binparser.py
@@ -1546,7 +1546,7 @@ class BIN_Token(Token):
 
     def matches(self, terminal: Terminal) -> bool:
         """Return True if this token matches the given terminal"""
-        return self.match_with_meaning(cast(BIN_Terminal, terminal)) != False
+        return self.match_with_meaning(cast(BIN_Terminal, terminal)) != False # noqa: E712
 
     def __repr__(self) -> str:
         return "[" + self.kind + ": " + self.t1 + "]"

--- a/src/reynir/grammar.py
+++ b/src/reynir/grammar.py
@@ -1060,7 +1060,7 @@ class Grammar:
                             # Found a nonterminal to which this pragma applies
                             func(nonterminals[vname], param)
                             cnt += 1
-                        except:
+                        except Exception:
                             raise GrammarError(
                                 "Invalid pragma argument '{0}'".format(param),
                                 fname,
@@ -1376,7 +1376,7 @@ class Grammar:
         shortcuts: Dict[Nonterminal, Nonterminal] = {}
 
         for nt, plist in grammar.items():
-            if not "_" in nt.name:
+            if "_" not in nt.name:
                 # 'Pure' nonterminal with no variants: don't shortcut
                 continue
             if self.nt_score(nt) != 0 or nt.has_tags:


### PR DESCRIPTION
* CI updated to include CPython 3.14 and PyPy 3.11 in test matrix
* CI now runs `ruff` linter
* CI uses `uv` for faster dependency installation
* Project migrated as much as possible over to `pyproject.toml`
* Minor fixes to silence linter complaints
* Bumped dependency versions
* Bumped package version to 3.5.8