### PR TITLE
Fix undefined symbol __gxx_personality_v0 on Linux CPython builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reynir"
-version = "3.6.1"
+version = "3.6.2"
 description = "A natural language parser for Icelandic"
 authors = [{ name = "Miðeind ehf.", email = "mideind@mideind.is" }]
 maintainers = [{ name = "Miðeind ehf.", email = "mideind@mideind.is" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires-python = ">=3.9"
 dependencies = [
     "cffi>=1.17.1",
     "tokenizer>=3.6.0",
-    "islenska>=1.0.4",
+    "islenska>=1.3.2",
     "typing_extensions",
 ]
 

--- a/src/reynir/eparser_build.py
+++ b/src/reynir/eparser_build.py
@@ -135,9 +135,14 @@ else:
     extra_compile_args = ["-std=c++11"]
 
 # On some systems, the linker needs to be told to use the C++ compiler
-# under PyPy due to changes in the default behaviour of distutils.
+# due to changes in the default behaviour of distutils/setuptools, which
+# otherwise link the C++ extension with the C driver and omit libstdc++,
+# causing an "undefined symbol: __gxx_personality_v0" ImportError at runtime.
 if IMPLEMENTATION == "PyPy":
     os.environ["LDCXXSHARED"] = "c++ -shared"
+elif not WINDOWS and not MACOS:
+    os.environ.setdefault("LDSHARED", "c++ -shared")
+    os.environ.setdefault("LDCXXSHARED", "c++ -shared")
 
 # Use the Python stable ABI (abi3) for CPython, allowing a single wheel
 # to work across multiple Python versions (3.9+). PyPy doesn't support abi3.


### PR DESCRIPTION
Recent setuptools links the C++ `_eparser` extension with the C driver, which omits `libstdc++` and leaves `__gxx_personality_v0` undefined — causing an `ImportError` at import time on Linux CPython.

Force the C++ link driver (`LDSHARED`/`LDCXXSHARED`) for non-Windows, non-macOS CPython builds, extending the existing PyPy workaround. Mirrors the fix in Icegrams PR #7.

Bumps version to 3.6.2.