### PR TITLE
Tag CPython wheels as abi3 (cp310-abi3); release 3.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reynir"
-version = "3.7.0"
+version = "3.7.1"
 description = "A natural language parser for Icelandic"
 authors = [{ name = "Miðeind ehf.", email = "mideind@mideind.is" }]
 maintainers = [{ name = "Miðeind ehf.", email = "mideind@mideind.is" }]

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,23 @@ This file is retained for CFFI compilation.
 All package metadata is defined in pyproject.toml.
 """
 
+import platform
+
 from setuptools import setup
+
+options = {}
+if platform.python_implementation() == "CPython":
+    # Tag CPython wheels with the stable ABI (e.g. cp310-abi3), so that a
+    # single wheel serves all CPython versions >= 3.10. The extension
+    # module itself is compiled with Py_LIMITED_API via the py_limited_api
+    # flag in eparser_build.py; this option makes the *wheel tag* reflect
+    # that. Not applicable to PyPy, which has no stable ABI.
+    options = {"bdist_wheel": {"py_limited_api": "cp310"}}
 
 # The cffi_modules and zip_safe settings are not yet supported in pyproject.toml
 # and must be defined here.
 setup(
     zip_safe=True,
     cffi_modules=["src/reynir/eparser_build.py:ffibuilder"],
+    options=options,
 )

--- a/src/reynir/eparser_build.py
+++ b/src/reynir/eparser_build.py
@@ -152,7 +152,11 @@ elif not WINDOWS and not MACOS:
 
 # Use the Python stable ABI (abi3) for CPython, allowing a single wheel
 # to work across multiple Python versions (3.9+). PyPy doesn't support abi3.
-py_limited_api = "cp39" if IMPLEMENTATION == "CPython" else False
+# Compile the extension against the stable ABI (Py_LIMITED_API) on
+# CPython, producing an _eparser.abi3.so module usable on any CPython
+# version >= 3.10. The matching cp310-abi3 wheel tag is set via the
+# bdist_wheel py_limited_api option in setup.py.
+py_limited_api = "cp310" if IMPLEMENTATION == "CPython" else False
 
 ffibuilder.cdef(declarations + callbacks)
 

--- a/uv.lock
+++ b/uv.lock
@@ -409,7 +409,7 @@ wheels = [
 
 [[package]]
 name = "reynir"
-version = "3.7.0"
+version = "3.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "cffi" },


### PR DESCRIPTION
## Summary

The extension module has always been compiled against the stable ABI (the `py_limited_api` flag in `eparser_build.py` produces `_eparser.abi3.so`), but `bdist_wheel` was never informed, so published wheels were tagged `cp3X-cp3X` and only served the exact Python version they were built with — every other CPython version silently fell back to building from the sdist (observed for 3.7.0 and all earlier releases; e.g. 3.6.2 ships `cp39-cp39` wheels).

This PR passes the `py_limited_api` option to `bdist_wheel` via `setup()` (CPython only — PyPy has no stable ABI), so a single `cp310-abi3` wheel serves all CPython versions >= 3.10. The extension's limited API target is bumped from `cp39` to `cp310` to match the supported floor, and the version is bumped to 3.7.1.

## Test plan

- Local build produces `reynir-3.7.1-cp310-abi3-linux_x86_64.whl`
- That single wheel (built under Python 3.13) installs and parses correctly on both Python 3.10 and 3.14
- Full test suite green (119 tests)
- Post-release: PyPI smoke test verifying that CPython 3.13 now receives the binary wheel instead of the sdist

🤖 Generated with [Claude Code](https://claude.com/claude-code)